### PR TITLE
Remove legacy SimplyCoreAudioC imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 | -------------:|:------------- |:--------:|
 | 4.1.1         | Added synchronized access to `allKnownDevices` in `AudioHardware`. | June 30, 2023 |
 |               | Added support for `.network` and `.other` transport types. ||
+| 4.1.2         | Dropped legacy `SimplyCoreAudioC` import; modern Swift no longer requires it. | June 14, 2025 |
 | 4.1.0         | Following upstream changes in AudioToolbox and deprecations (as of macOS 12.0) in CoreAudio, switched all (swift) instances of `master` and `Master` to respective `main` & `Main`; <br />added deprecated versions of call-sites for backwards compatibility (with warnings) until 5.0 (@donaldguy) | July 30, 2021 |
 | 4.0.1         | Fixed typo in `AudioHardware.allOutputDevices` (@mattgreen) | April 9th, 2021 |
 |                  | Minor optimizations in `AudioObject` property listeners. ||

--- a/Sources/SimplyCoreAudio/Public/AudioDevice+VirtualMainOutput.swift
+++ b/Sources/SimplyCoreAudio/Public/AudioDevice+VirtualMainOutput.swift
@@ -8,7 +8,6 @@
 import AudioToolbox
 import CoreAudio
 import Foundation
-@_implementationOnly import SimplyCoreAudioC
 
 // MARK: - 🔊 Virtual Main Output Volume / Balance Functions
 

--- a/Sources/SimplyCoreAudio/Public/Enums/Element.swift
+++ b/Sources/SimplyCoreAudio/Public/Enums/Element.swift
@@ -6,7 +6,6 @@
 
 import CoreAudio
 import Foundation
-@_implementationOnly import SimplyCoreAudioC
 
 public enum Element {
     case main

--- a/Sources/SimplyCoreAudio/Public/SimplyCoreAudio+Aggregate.swift
+++ b/Sources/SimplyCoreAudio/Public/SimplyCoreAudio+Aggregate.swift
@@ -8,7 +8,6 @@
 import CoreAudio
 import Foundation
 import os.log
-@_implementationOnly import SimplyCoreAudioC
 
 // MARK: - Create and Destroy Aggregate Devices
 


### PR DESCRIPTION
## Summary
- drop `@_implementationOnly import SimplyCoreAudioC` from public sources
- record this removal in the changelog

Modern Xcode includes these CoreAudio constants directly, so the private bridging module is only needed for legacy toolchains.

## Testing
- No tests run (macOS-only dependencies)

------
https://chatgpt.com/codex/tasks/task_e_684d25e3097c83308444db77238b1687