### PR TITLE
Add prototype CMake file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.15)
+project(SimplyCoreAudio LANGUAGES Swift)
+
+include(FetchContent)
+FetchContent_Declare(
+    swift-atomics
+    GIT_REPOSITORY https://github.com/apple/swift-atomics.git
+    GIT_TAG        1.0.0
+)
+FetchContent_MakeAvailable(swift-atomics)
+
+file(GLOB_RECURSE SIMPLYCOREAUDIO_SOURCES
+    "Sources/SimplyCoreAudio/*.swift"
+)
+
+add_library(SimplyCoreAudio ${SIMPLYCOREAUDIO_SOURCES})
+
+# Link against the Atomics package
+# CoreAudio and related frameworks are expected to be provided by the host system
+# when building on macOS.
+target_link_libraries(SimplyCoreAudio
+    PUBLIC
+        Atomics
+)
+
+# Tests
+file(GLOB_RECURSE SIMPLYCOREAUDIO_TEST_SOURCES
+    "Tests/SimplyCoreAudioTests/*.swift"
+)
+
+if(SIMPLYCOREAUDIO_TEST_SOURCES)
+    add_executable(SimplyCoreAudioTests ${SIMPLYCOREAUDIO_TEST_SOURCES})
+    target_link_libraries(SimplyCoreAudioTests
+        PRIVATE
+            SimplyCoreAudio
+    )
+    enable_testing()
+    add_test(NAME SimplyCoreAudioSuite COMMAND SimplyCoreAudioTests)
+endif()
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ include(FetchContent)
 FetchContent_Declare(
     swift-atomics
     GIT_REPOSITORY https://github.com/apple/swift-atomics.git
-    GIT_TAG        1.0.0
+    GIT_TAG        1.3.0
 )
 FetchContent_MakeAvailable(swift-atomics)
 
@@ -13,7 +13,7 @@ file(GLOB_RECURSE SIMPLYCOREAUDIO_SOURCES
     "Sources/SimplyCoreAudio/*.swift"
 )
 
-add_library(SimplyCoreAudio ${SIMPLYCOREAUDIO_SOURCES})
+add_library(SimplyCoreAudio STATIC ${SIMPLYCOREAUDIO_SOURCES})
 
 # Link against the Atomics package
 # CoreAudio and related frameworks are expected to be provided by the host system


### PR DESCRIPTION
## Summary
- provide a `CMakeLists.txt` prototype for building the Swift library
- pull `swift-atomics` via `FetchContent`
- build library and tests, omitting `SimplyCoreAudioC`

## Testing
- `uname -a`

------
https://chatgpt.com/codex/tasks/task_e_684d95fa6fcc833094557ce130215e99